### PR TITLE
[fix] Script not working on MacOS

### DIFF
--- a/wordpwn.py
+++ b/wordpwn.py
@@ -40,6 +40,8 @@ def generate_plugin(LHOST, LPORT, PAYLOAD):
 	print("[*] Checking if msfvenom installed")
 	if "msfvenom" in os.listdir("/usr/bin/"):
 		print("[+] msfvenom installed")
+	elif "msfvenom" in os.listdir("/opt/metasploit-framework/bin/"):
+		print("[+] msfvenom installed (MacOS)")
 	else:
 		print("[-] msfvenom not installed")
 		sys.exit()


### PR DESCRIPTION
The script was not functioning on MacOS since the msfvenom location in MacOS is different than Linux. Fix this issue by adding the MacOS location to the msfvenom is installed check.